### PR TITLE
add python capability and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ The rest of these files will largely not need updated though a brief description
 * _brand.yml -- Logo and favicon definition
 * config_automation.yml	-- Configurations for the OTTR Template automations. Update this file to toggle spelling or url check as well as minimum errors allowed for those checks or to update the docker image.
 
+*To update the docker image*, replace the `rendering-docker-image:` option in `config_automation.yml` to the docker image that has the packages you need.
+* `jhudsl/base_ottr:main` is the default and works for most tidyverse/R needs
+* `jhudsl/ottr_python:main` should meet basic python needs
+* `jhudsl/ottr_ml:main` should meet most machine learning with python needs
+* Additional docker images that work within the OTTR framework can be found here: https://github.com/ottrproject/ottr-docker/tree/main
+* For specific needs within the OCS organization, let Kate Isaac (`@kweav` on GitHub) know and an image can be developed to your specifications.
+
 ### Directories
 
 * `data/`: Raw, imported, and wrangled datasets. `raw/pm25_data.csv`, `imported/pm25_data_imported.rda`, and `wrangled_data.csv` are template files that can be removed or overwritten by case study repositories.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The rest of these files will largely not need updated though a brief description
 * `jhudsl/base_ottr:main` is the default and works for most tidyverse/R needs
 * `jhudsl/ottr_python:main` should meet basic python needs
 * `jhudsl/ottr_ml:main` should meet most machine learning with python needs
+* Developing `jhudsl/ottr_ocs_py` (`dev` tag not `main`) because working with h5 files needs a dependency that `jhudsl/ottr_python` doesn't have and h5 files are common in bioinformatics
 * Additional docker images that work within the OTTR framework can be found here: https://github.com/ottrproject/ottr-docker/tree/main
 * For specific needs within the OCS organization, let Kate Isaac (`@kweav` on GitHub) know and an image can be developed to your specifications.
 

--- a/_data_import.qmd
+++ b/_data_import.qmd
@@ -19,9 +19,7 @@ put the data files as they came from the source into a 'data/raw/' subfolder
 and use the `here` package. See the following example and update with your data:
 -->
 
-{.panel-tabset}
-
-:::
+::: {.panel-tabset}
 
 ## R
 
@@ -42,9 +40,7 @@ At the end of the data import section, save the imported data as .rda files
 to allow users to stop and pick up where they left off:
 -->
 
-{.panel-tabset}
-
-:::
+::: {.panel-tabset}
 
 ## R
 

--- a/_data_import.qmd
+++ b/_data_import.qmd
@@ -19,18 +19,46 @@ put the data files as they came from the source into a 'data/raw/' subfolder
 and use the `here` package. See the following example and update with your data:
 -->
 
+{.panel-tabset}
+
+:::
+
+## R
+
 ```{r}
 pm <-readr::read_csv(here("data", "raw", "pm25_data.csv"))
 ```
+
+## Python
+
+```{python}
+pm = pd.read_csv("data/raw/pm25_data.csv")
+```
+
+:::
 
 <!--
 At the end of the data import section, save the imported data as .rda files
 to allow users to stop and pick up where they left off:
 -->
 
+{.panel-tabset}
+
+:::
+
+## R
+
 ```{r}
 save(pm, file = here::here("data", "imported", "pm25_data_imported.rda"))
 ```
+
+## Python
+
+```{python}
+pm.to_hdf("data/imported/pm_data_imported.h5", 'pm', format='table')
+```
+
+:::
 
 <!--
 NOTE that depending on the size of the data for Bio-OCS, the data may not be in the case study project folder directly

--- a/_data_import.qmd
+++ b/_data_import.qmd
@@ -51,7 +51,7 @@ save(pm, file = here::here("data", "imported", "pm25_data_imported.rda"))
 ## Python
 
 ```{python}
-pm.to_hdf("data/imported/pm_data_imported.h5", 'pm', format='table')
+pm.to_hdf("data/imported/pm_data_imported.h5", key='pm', format='table')
 ```
 
 :::

--- a/_data_wrangling.qmd
+++ b/_data_wrangling.qmd
@@ -15,9 +15,7 @@ At the end of this section, save incremental data so that users can pause and co
 
 If you have been following along but stopped, we could load our imported data like so:
 
-{.panel-tabset}
-
-:::
+::: {.panel-tabset}
 
 ## R
 
@@ -52,9 +50,7 @@ This includes an example of code annotation with Quarto. See the documentation f
 
 To allow users to skip import and wrangling we will save the data as an RDA file as well as a CSV file as this is often useful to send our data to collaborators. We will save this in a “wrangled” subdirectory of our “data” directory of our working directory.
 
-{.panel-tabset}
-
-:::
+::: {.panel-tabset}
 
 ## R
 

--- a/_data_wrangling.qmd
+++ b/_data_wrangling.qmd
@@ -70,7 +70,7 @@ Note that with this code annotation example, we've used a new line to space the 
 ## Python
 
 ```{python}
-pm.to_hdf("data/wrangled/wrangled_data.h5", 'pm', format='table')
+pm.to_hdf("data/wrangled/wrangled_data.h5", key = 'pm', format='table')
 pm.to_csv("data/wrangled/wrangled_data_py.csv")
 ```
 

--- a/_data_wrangling.qmd
+++ b/_data_wrangling.qmd
@@ -15,9 +15,23 @@ At the end of this section, save incremental data so that users can pause and co
 
 If you have been following along but stopped, we could load our imported data like so:
 
+{.panel-tabset}
+
+:::
+
+## R
+
 ```{r}
 load(here::here("data", "imported", "pm25_data_imported.rda"))
 ```
+## Python
+
+```{python}
+pm = pd.read_hdf("data/imported/pm_data_imported.h5", key = "pm")
+```
+
+:::
+
 ***
 
 <details> <summary> If you skipped the data import section click here. </summary>
@@ -38,6 +52,12 @@ This includes an example of code annotation with Quarto. See the documentation f
 
 To allow users to skip import and wrangling we will save the data as an RDA file as well as a CSV file as this is often useful to send our data to collaborators. We will save this in a “wrangled” subdirectory of our “data” directory of our working directory.
 
+{.panel-tabset}
+
+:::
+
+## R
+
 ```{r}
 save(pm, file = here::here("data", "wrangled", "wrangled_data.rda")) # <1>
 readr::write_csv(pm, file = here::here("data","wrangled",            # <2>
@@ -51,8 +71,19 @@ readr::write_csv(pm, file = here::here("data","wrangled",            # <2>
 Note that with this code annotation example, we've used a new line to space the code so that the annotation doesn't overlay the code
 -->
 
+## Python
+
+```{python}
+pm.to_hdf("data/wrangled/wrangled_data.h5", 'pm', format='table')
+pm.to_csv("data/wrangled/wrangled_data_py.csv")
+```
+
+:::
+
 <!--
 Replace `pm` above with the name of the data object created at the end of data wrangling.
 -->
+
+
 
 ***

--- a/_packages.qmd
+++ b/_packages.qmd
@@ -6,6 +6,11 @@ Fill out the table and add rows as necessary providing a link to the source and 
 
 We will begin by loading the packages that we will need:
 
+{.panel-tabset}
+:::
+
+## R
+
 ```{r}
 #add library() calls
 library(here)
@@ -16,5 +21,17 @@ Package    | Use
 [{Package Name}]({Documentation URL}){target="_blank"}      | {Package use}
 [{Package Name}]({Documentation URL}){target="_blank"}      | {Package use}
 
-
 The first time we use a function, we will use the `::` to indicate which package we are using. Unless we have overlapping function names, this is not necessary, but we will include it here to be informative about where the functions we will use come from.
+
+## Python
+
+```{python}
+import pandas as pd
+```
+
+Package    | Use
+---------- |-------------
+[{Package Name}]({Documentation URL}){target="_blank"}      | {Package use}
+[{Package Name}]({Documentation URL}){target="_blank"}      | {Package use}
+
+:::

--- a/_packages.qmd
+++ b/_packages.qmd
@@ -6,8 +6,7 @@ Fill out the table and add rows as necessary providing a link to the source and 
 
 We will begin by loading the packages that we will need:
 
-{.panel-tabset}
-:::
+::: {.panel-tabset}
 
 ## R
 

--- a/config_automation.yml
+++ b/config_automation.yml
@@ -28,4 +28,4 @@ render-website: quarto_web
 
 # What docker image should be used for rendering?
 # The default is jhudsl/base_ottr:main
-rendering-docker-image: 'jhudsl/ottr_python:main'
+rendering-docker-image: 'jhudsl/ottr_ocs_py:dev'

--- a/config_automation.yml
+++ b/config_automation.yml
@@ -28,4 +28,4 @@ render-website: quarto_web
 
 # What docker image should be used for rendering?
 # The default is jhudsl/base_ottr:main
-rendering-docker-image: 'jhudsl/base_ottr:main'
+rendering-docker-image: 'jhudsl/ottr_python:main'


### PR DESCRIPTION
Adding python capability as well as some examples reading and saving data. Added note to readme about how to switch rendering docker image and noting a few worthwhile images.

related: https://github.com/ottrproject/ottr-docker/pull/16