### PR TITLE
Add Bibliography Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The rest of these files will largely not need updated though a brief description
 * `img/`: This is where images should go for the case study background, motivation, etc.
   - [ ] Replace the `mainplot.png` from the template with your main plot
   - [ ] Add any additional case study specific (non-template) images in this directory
-* `resources/`: Files related to OTTR checks (e.g., dictionary and a file of URLs to exclude/ignore from checking.).
+* `resources/`: Files related to OTTR checks (e.g., dictionary and a file of URLs to exclude/ignore from checking.). Also the `references.bib` file for citations.
 * `.github/`: workflow files supporting the OTTR template automations
 * `docs/`: the rendered files that GitHub pages will use -- refreshed through OTTR template automations.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ For the overall content of the Open Case Study, each portion of the case study i
 * [ ] _motivation.qmd
   * Provides an example of including images with Quarto (including those that you can click to open in a larger preview)
   * Provides an example of a custom definition box
+  * Provides an example of citing a reference
 * [ ] _main_question.qmd
 * [ ] _los.qmd
   * [ ] _data_science_los.qmd

--- a/_additional_info.qmd
+++ b/_additional_info.qmd
@@ -5,7 +5,7 @@
 Use this section to provide any additional information or resources on the topic and methods covered in the case study
 -->
 
-## References
+## References {#ref-section}
 
 ::: {#refs}
 :::

--- a/_additional_info.qmd
+++ b/_additional_info.qmd
@@ -5,6 +5,11 @@
 Use this section to provide any additional information or resources on the topic and methods covered in the case study
 -->
 
+## References
+
+::: {#refs}
+:::
+
 ## **Helpful Links**
 ***
 

--- a/_motivation.qmd
+++ b/_motivation.qmd
@@ -22,6 +22,6 @@ Images are very helpful within this section....
 
 ![](img/motivation_map_of_monitors.jpg){fig-alt="Map showing location of air pollution monitors across the US." width=800 .lightbox}
 
-In these background citations, you may want to reference information like [@knuth84]. These will automatically be added into the @ref-section subsection of the Additional Information section.
+In these background citations, you may want to reference information like [@knuth84]. These will automatically be added into the @ref-section subsection of the Additional Information section. See the references.bib file for where @knuth84 came from. Tools like Zotero can help you get the bib version of the citation and some journals will help you copy paste it more readily.
 
 ***

--- a/_motivation.qmd
+++ b/_motivation.qmd
@@ -22,6 +22,6 @@ Images are very helpful within this section....
 
 ![](img/motivation_map_of_monitors.jpg){fig-alt="Map showing location of air pollution monitors across the US." width=800 .lightbox}
 
-In these background citations, you may want to reference information like [@knuth84]. These will automatically be added into the @ref-section subsection of the Additional Information section. See the references.bib file for where @knuth84 came from. Tools like Zotero can help you get the bib version of the citation and some journals will help you copy paste it more readily.
+In these background citations, you may want to reference information like [knuth, 1984](https://doi.org/10.1093/comjnl/27.2.97) [@knuth84]. These will automatically be added into the @ref-section subsection of the Additional Information section. It is good to also add a direct link the the reference where appropriate.  See the references.bib file for where `@knuth84` came from. Tools like Zotero can help you get the bib version of the citation and some journals will help you copy paste it more readily.
 
 ***

--- a/_motivation.qmd
+++ b/_motivation.qmd
@@ -22,4 +22,6 @@ Images are very helpful within this section....
 
 ![](img/motivation_map_of_monitors.jpg){fig-alt="Map showing location of air pollution monitors across the US." width=800 .lightbox}
 
+In these background citations, you may want to reference information like [@knuth84]. These will automatically be added into the @ref-section subsection of the Additional Information section.
+
 ***

--- a/index.qmd
+++ b/index.qmd
@@ -1,5 +1,6 @@
 ---
 title: "**Biomedical Open Case Studies: {Title}**"
+bibliography: references.bib
 include-sections:
   stat-los: false
   data-import: true

--- a/index.qmd
+++ b/index.qmd
@@ -1,6 +1,6 @@
 ---
 title: "**Biomedical Open Case Studies: {Title}**"
-bibliography: references.bib
+bibliography: resources/references.bib
 include-sections:
   stat-los: false
   data-import: true

--- a/resources/dictionary.txt
+++ b/resources/dictionary.txt
@@ -17,6 +17,7 @@ glyphicons
 HTTPS
 hw
 iconpacks
+knuth
 lightblue
 lightbox
 lightgreen

--- a/resources/dictionary.txt
+++ b/resources/dictionary.txt
@@ -35,3 +35,4 @@ subdir
 tabset
 th
 www
+Zotero

--- a/resources/references.bib
+++ b/resources/references.bib
@@ -1,0 +1,17 @@
+@article{knuth84,
+  author = {Knuth, Donald E.},
+  title = {Literate Programming},
+  year = {1984},
+  issue_date = {May 1984},
+  publisher = {Oxford University Press, Inc.},
+  address = {USA},
+  volume = {27},
+  number = {2},
+  issn = {0010-4620},
+  url = {https://doi.org/10.1093/comjnl/27.2.97},
+  doi = {10.1093/comjnl/27.2.97},
+  journal = {Comput. J.},
+  month = may,
+  pages = {97–111},
+  numpages = {15}
+}


### PR DESCRIPTION
In this Pull Request, I'm enabling a references section within the Additional Information section at the end of the case study.

I've included

* a `resources/references.bib` file with an example reference
* a place for the references to appear within the additional information section
* an example of citing a reference within the motivation section
* updates to the README

Sources for these updates: https://quarto.org/docs/authoring/citations.html, https://quarto.org/docs/authoring/cross-references.html