### PR TITLE
Add in glossary functionality from quarto extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This specific template sets up the style and content template for Biomedical Ope
     * [ ] line 11
     * [ ] line 28
 
+* glossary.yml: stores terms to be defined where users can click on the term and see the definition.
+
 The rest of these files will largely not need updated though a brief description of what each contains is provided.
 
 * styles.css -- Defines html elements
@@ -61,6 +63,7 @@ For the overall content of the Open Case Study, each portion of the case study i
   * Provides an example of including images with Quarto (including those that you can click to open in a larger preview)
   * Provides an example of a custom definition box
   * Provides an example of citing a reference
+  * Provides examples of using the glossary extension to define terms
 * [ ] _main_question.qmd
 * [ ] _los.qmd
   * [ ] _data_science_los.qmd

--- a/_additional_info.qmd
+++ b/_additional_info.qmd
@@ -5,7 +5,41 @@
 Use this section to provide any additional information or resources on the topic and methods covered in the case study
 -->
 
+## Glossary
+***
+
+```{r}
+#| results: asis
+#| echo: false
+
+library(yaml)
+
+glossary_table <- function(path = "glossary.yml") {
+
+  g <- yaml::read_yaml(path)
+  g_sorted <- g[order(names(g))]
+
+  out <- c(
+    "<table class='glossary_table'>",
+    "<tr><th><b>Term</b></th><th><b>Definition</b></th></tr>"
+  )
+
+  for (term in names(g_sorted)) {
+    def <- paste(g_sorted[[term]], collapse = "\n")
+    row <- sprintf("<tr><td>%s</td><td>%s</td></tr>", term, def)
+    out <- c(out, row)
+  }
+
+  out <- c(out, "</table>")
+
+  knitr::asis_output(paste(out, collapse = "\n"))
+}
+
+glossary_table("glossary.yml")
+```
+
 ## References
+***
 
 ::: {#refs}
 :::

--- a/_extensions/debruine/glossary/_extension.yml
+++ b/_extensions/debruine/glossary/_extension.yml
@@ -1,0 +1,7 @@
+title: Glossary
+author: Lisa DeBruine
+version: 1.0.0
+quarto-required: ">=1.2.0"
+contributes:
+  shortcodes:
+    - glossary.lua

--- a/_extensions/debruine/glossary/glossary.css
+++ b/_extensions/debruine/glossary/glossary.css
@@ -1,0 +1,56 @@
+.glossary {
+  color: purple;
+  text-decoration: underline;
+  cursor: help;
+  position: relative;
+  border: none;
+  padding: 0;
+}
+
+/* only needed for popup = "click" */
+/* popup-definition */
+.glossary .def {
+  display: none;
+  position: absolute;
+  z-index: 1;
+  width: 200px;
+  bottom: 100%;
+  left: 50%;
+  margin-left: -100px;
+  background-color: #333;
+  color: white;
+  padding: 5px;
+  border-radius: 6px;
+}
+/* show on click */
+.glossary:active .def {
+  display: inline-block;
+}
+/* triangle arrow */
+.glossary:active .def::after {
+  content: ' ';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: #333 transparent transparent transparent;
+}
+
+/* glossary table styles */
+.glossary_table td {
+  vertical-align: top;
+}
+
+.glossary_table td:first-child {
+  padding-right: 1em;
+}
+
+.glossary_table tr {
+  border-bottom: 1px solid #ddd;
+}
+
+.glossary_table tr:nth-child(even) {
+  background-color: #99999933;
+}

--- a/_extensions/debruine/glossary/glossary.lua
+++ b/_extensions/debruine/glossary/glossary.lua
@@ -1,0 +1,174 @@
+-- Glossary.lua
+-- Author: Lisa DeBruine
+
+-- Global glossary table
+globalGlossaryTable = {}
+
+-- Helper Functions
+
+local function addHTMLDeps()
+  -- add the HTML requirements for the library used
+    quarto.doc.add_html_dependency({
+    name = 'glossary',
+    stylesheets = {'glossary.css'}
+  })
+end
+
+local function kwExists(kwargs, keyword)
+    for key, value in pairs(kwargs) do
+        if key == keyword then
+            return true
+        end
+    end
+    return false
+end
+
+-- Function to sort a Lua table by keys
+function sortByKeys(tbl)
+    local sortedKeys = {}
+
+    -- Extract keys from the table and store them in the 'sortedKeys' array
+    for key, _ in pairs(tbl) do
+        table.insert(sortedKeys, key)
+    end
+
+    -- Sort the keys alphabetically
+    table.sort(sortedKeys)
+
+    -- Create a new table with the sorted keys
+    local sortedTable = {}
+    for _, key in pairs(sortedKeys) do
+        sortedTable[key] = tbl[key]
+    end
+
+    return sortedTable
+end
+
+local function read_metadata_file(fname)
+  local metafile = io.open(fname, 'r')
+  local content = metafile:read("*a")
+  metafile:close()
+  local metadata = pandoc.read(content, "markdown").meta
+  return metadata
+end
+
+local function readGlossary(path)
+  local f = io.open(path, "r")
+  if not f then
+    io.stderr:write("Cannot open file " .. path)
+  else
+    local lines = f:read("*all")
+    f:close()
+    return(lines)
+  end
+end
+
+---Merge user provided options with defaults
+---@param userOptions table
+local function mergeOptions(userOptions, meta)
+  local defaultOptions = {
+    path = "glossary.yml",
+    popup = "hover",
+    show = true,
+    add_to_table = true
+  }
+
+  -- override with meta values first
+  if meta.glossary ~= nil then
+    for k, v in pairs(meta.glossary) do
+      local value = pandoc.utils.stringify(v)
+      if value == 'true' then value = true end
+      if value == 'false' then value = false end
+      defaultOptions[k] = value
+    end
+  end
+
+  -- then override with function keyword values
+  if userOptions ~= nil then
+    for k, v in pairs(userOptions) do
+      local value = pandoc.utils.stringify(v)
+      if value == 'true' then value = true end
+      if value == 'false' then value = false end
+      defaultOptions[k] = value
+    end
+  end
+
+  return defaultOptions
+end
+
+
+-- Main Glossary Function Shortcode
+
+return {
+
+["glossary"] = function(args, kwargs, meta)
+
+  -- this will only run for HTML documents
+  if not quarto.doc.isFormat("html:js") then
+    return pandoc.Null()
+  end
+
+  addHTMLDeps()
+
+  -- create glossary table
+  if kwExists(kwargs, "table") then
+    local gt = "<table class='glossary_table'>\n"
+    gt = gt .. "<tr><th> Term </th><th> Definition </th></tr>\n"
+
+    local sortedTable = sortByKeys(globalGlossaryTable)
+
+    for key, value in pairs(sortedTable) do
+        gt = gt .. "<tr><td>" .. key
+        gt = gt .. "</td><td>" .. value .. "</td></tr>\n"
+    end
+    gt = gt .. "</table>"
+
+    return pandoc.RawBlock('html', gt)
+  end
+
+  -- or set up in-text term
+  local options = mergeOptions(kwargs, meta)
+
+  local display = pandoc.utils.stringify(args[1])
+  local term = string.lower(display)
+
+  if kwExists(kwargs, "display") then
+    display = pandoc.utils.stringify(kwargs.display)
+  end
+
+  -- get definition
+  local def = ""
+  if kwExists(kwargs, "def") then
+    def = pandoc.utils.stringify(kwargs.def)
+  else
+    local metafile = io.open(options.path, 'r')
+    local content = "---\n" .. metafile:read("*a") .. "\n---\n"
+    metafile:close()
+    local glossary = pandoc.read(content, "markdown").meta
+    for key, value in pairs(glossary) do
+      glossary[string.lower(key)] = value
+    end
+    -- quarto.log.output()
+    if kwExists(glossary, term) then
+      def = pandoc.utils.stringify(glossary[term])
+    end
+  end
+
+  -- add to global table
+  if options.add_to_table then
+    globalGlossaryTable[term] = def
+  end
+
+  if options.popup == "hover" then
+    glosstext = "<button class='glossary' title='" .. def .."'>" .. display .. "</button>"
+  elseif options.popup == "click" then
+    glosstext = "<button class='glossary'><span class='def'>" .. def .."</span>" .. display .. "</button>"
+  elseif options.popup == "none" then
+    glosstext = "<button class='glossary'>" .. display .. "</button>"
+  end
+
+  return pandoc.RawInline("html", glosstext)
+
+end
+
+}

--- a/_motivation.qmd
+++ b/_motivation.qmd
@@ -24,4 +24,15 @@ Images are very helpful within this section....
 
 In these background citations, you may want to reference information like [knuth, 1984](https://doi.org/10.1093/comjnl/27.2.97) [@knuth84]. These will automatically be added into the References subsection of the Additional Information section near the end of the case study. It is good to also add a direct link the the reference where appropriate. See the `references.bib` file for where `@knuth84` came from. Tools like Zotero can help you get the bib version of the citation and some journals will help you copy paste it more readily.
 
+This template also utilizes a [quarto extension](https://github.com/debruine/quarto-glossary) to enable some glossary functionality. {{< glossary "Term 1" >}} is an example where if you click and hold "Term 1", the definition stored in `glossary.yml` for "Term 1" will be displayed. `{{< glossary Term2 >}}` will unlock the same functionality for `Term2` also stored in `glossary.yml`. Adding terms to `glossary.yml` uses the following pattern. Note the two spaces at the beginning of each definition line.
+
+```
+Term 1: |
+  Definition of Term 1
+Term2: |
+  Definition of Term2
+```
+
+We've added code to print out all of the terms stored in `glossary.yml` as a table within the Additional Information section before listing references.
+
 ***

--- a/_motivation.qmd
+++ b/_motivation.qmd
@@ -33,6 +33,6 @@ Term2: |
   Definition of Term2
 ```
 
-We've added code to print out all of the terms stored in `glossary.yml` as a table within the Additional Information section before listing references.
+We've added code to print out all of the terms stored in `glossary.yml` as a table within the Additional Information section before listing references. Note that this is in place of the table functionality from the extension and this will display every term in the yml file whether it is referenced in the case study or not.
 
 ***

--- a/_motivation.qmd
+++ b/_motivation.qmd
@@ -33,6 +33,6 @@ Term2: |
   Definition of Term2
 ```
 
-We've added code to print out all of the terms stored in `glossary.yml` as a table within the Additional Information section before listing references. Note that this is in place of the table functionality from the extension and this will display every term in the yml file whether it is referenced in the case study or not.
+We've added code to print out all of the terms stored in `glossary.yml` as a table within the Additional Information section before listing references. Note that this is in place of the table functionality from the extension and this will display every term in the `.yml` file whether it is referenced in the case study or not.
 
 ***

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -27,6 +27,11 @@ website:
       - icon: github
         href: https://github.com/opencasestudies/ocs-template-quarto
 
+glossary:
+  path: glossary.yml
+  popup: click
+  show: true
+
 brand: _brand.yml
 format:
   html:

--- a/glossary.yml
+++ b/glossary.yml
@@ -1,0 +1,4 @@
+Term 1: |
+  Definition of Term 1
+Term2: |
+  Definition of Term 2


### PR DESCRIPTION
Added a `glossary.yml` file, added the extension files, added an example of using the glossary, and added the code to display a table from the glossary file.