### PR TITLE
move bibliography and glossary table to child qmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ This specific template sets up the style and content template for Biomedical Ope
     * [ ] line 11
     * [ ] line 28
 
-* glossary.yml: stores terms to be defined where users can click on the term and see the definition.
-
 The rest of these files will largely not need updated though a brief description of what each contains is provided.
 
+* `_bibliography.qmd` -- automatically adds the references that are included in `resources/references.bib` and referenced within the content `.qmd` files.
+* `_glossary_table.qmd` -- automatically builds the glossary table for **all** terms that are included in the `glossary.yml` file whether they are defined with the `{{< glossary term >}}` syntax within the content or not.
 * styles.css -- Defines html elements
 * _brand.yml -- Logo and favicon definition
 * config_automation.yml	-- Configurations for the OTTR Template automations. Update this file to toggle spelling or url check as well as minimum errors allowed for those checks or to update the docker image.
@@ -87,6 +87,8 @@ For the overall content of the Open Case Study, each portion of the case study i
 * [ ] _suggested_hw.qmd
 * [ ] _additional_info.qmd
 * [ ] _acknowledgements.qmd
+* [ ] glossary.yml: stores terms to be defined where users can click on the term and see the definition.
+
 
 * [ ] **Verify**
   * [ ] Every image ....

--- a/_additional_info.qmd
+++ b/_additional_info.qmd
@@ -5,45 +5,6 @@
 Use this section to provide any additional information or resources on the topic and methods covered in the case study
 -->
 
-## Glossary
-***
-
-```{r}
-#| results: asis
-#| echo: false
-
-library(yaml)
-
-glossary_table <- function(path = "glossary.yml") {
-
-  g <- yaml::read_yaml(path)
-  g_sorted <- g[order(names(g))]
-
-  out <- c(
-    "<table class='glossary_table'>",
-    "<tr><th><b>Term</b></th><th><b>Definition</b></th></tr>"
-  )
-
-  for (term in names(g_sorted)) {
-    def <- paste(g_sorted[[term]], collapse = "\n")
-    row <- sprintf("<tr><td>%s</td><td>%s</td></tr>", term, def)
-    out <- c(out, row)
-  }
-
-  out <- c(out, "</table>")
-
-  knitr::asis_output(paste(out, collapse = "\n"))
-}
-
-glossary_table("glossary.yml")
-```
-
-## References
-***
-
-::: {#refs}
-:::
-
 ## **Helpful Links**
 ***
 

--- a/_bibliography.qmd
+++ b/_bibliography.qmd
@@ -1,0 +1,5 @@
+## References
+***
+
+::: {#refs}
+:::

--- a/_glossary_table.qmd
+++ b/_glossary_table.qmd
@@ -1,0 +1,32 @@
+## Glossary
+***
+
+```{r}
+#| results: asis
+#| echo: false
+
+library(yaml)
+
+glossary_table <- function(path = "glossary.yml") {
+
+  g <- yaml::read_yaml(path)
+  g_sorted <- g[order(names(g))]
+
+  out <- c(
+    "<table class='glossary_table'>",
+    "<tr><th><b>Term</b></th><th><b>Definition</b></th></tr>"
+  )
+
+  for (term in names(g_sorted)) {
+    def <- paste(g_sorted[[term]], collapse = "\n")
+    row <- sprintf("<tr><td>%s</td><td>%s</td></tr>", term, def)
+    out <- c(out, row)
+  }
+
+  out <- c(out, "</table>")
+
+  knitr::asis_output(paste(out, collapse = "\n"))
+}
+
+glossary_table("glossary.yml")
+```

--- a/index.qmd
+++ b/index.qmd
@@ -75,6 +75,10 @@ include-sections:
 
 {{< include _additional_info.qmd >}}
 
+{{< include _glossary_table.qmd >}}
+
+{{< include _bibliography.qmd >}}
+
 ## **Session Info**
 ***
 


### PR DESCRIPTION
Moving the new "additional information" pieces from `_additional_info.qmd` which were added in PRs #41 and #39 to child documents that will get included within `index.qmd` to reduce the number of old qmd files that need updated within sync repositories. 

Also used shortcode to include these child qmd files within the larger `index.qmd` file after the `_additional_info.qmd` file

Updated the README to discuss these new files (which should not need updated)