### PR TITLE
specific file sync round 2

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -28,6 +28,18 @@ group:
         dest: _brand.yml
       - source: styles.css
         dest: styles.css
+      - source: index.qmd
+        dest: index.qmd
+      - source: _packages.qmd
+        dest: _packages.qmd
+      - source: _lo_map.qmd
+        dest: _lo_map.qmd
+      - source: _main_qs_answers_table.qmd
+        dest: _main_qs_answers_table.qmd
+      - source: auto-add-ai-disclaimer.lua
+        dest: auto-add-ai-disclaimer.lua
+      - source: resources/dictionary.txt
+        dest: resources/dictionary.txt
   # Repositories to receive changes
     repos: |
       opencasestudies/ocs-bio-single-cell


### PR DESCRIPTION
Round 2 of sending specific files for a sync from the template

**warning** don't want to merge, just want to document. Will send the sync from this branch, but don't want to incorporate these changes to main. **warning**

**PRs with updates since last sync:**

These PR files are part of this branch to send updates in the sync.

* https://github.com/opencasestudies/ocs-template-quarto/pull/57/changes --> 
  * `_packages.qmd`
* https://github.com/opencasestudies/ocs-template-quarto/pull/55/changes --> 
  * `resources/dictionary.txt`
  * `_lo_map.qmd`
  * `_main_qs_answers_table.qmd`
  * `index.qmd`
  * `styles.css`
* https://github.com/opencasestudies/ocs-template-quarto/pull/54/changes (and 56) -->
  * `auto-add-ai-disclaimer.lua`
  
This PR's files are not yet part of this branch to send updates in the sync. Wondering if it would be easier to ask people to update them or just open super small PRs in each repo adjusting them. Otherwise, people have to make sure their google analytics IDs don't get overwritten again
* https://github.com/opencasestudies/ocs-template-quarto/pull/52/changes -->
  * `_ocs_frontmatter.qmd` (adds a word "a" in the disclaimer and adds an "unless otherwise noted" for the license)
  * `_quarto.yml` (fixes the license url from hhttps to https)